### PR TITLE
Add Objective-C NSLog and Ruby p functions.

### DIFF
--- a/anyprint.py
+++ b/anyprint.py
@@ -125,6 +125,12 @@ prints = {
         'puts': print,
         'write': lambda x: print(x, end=''),
     },
+
+    # Objective-C
+    'NSLog': lambda *args: print(args[0].replace('%@', '%s') % args[1:]),
+
+    # Ruby
+    'p': lambda *args: print(*(repr(a) for a in args), sep='\n'),
 }
 
 


### PR DESCRIPTION
The Objective-C specific %@ specifier is emulated by naively replacing "%@" with "%s" in the format string.