### PR TITLE
python 2 compability

### DIFF
--- a/anyprint.py
+++ b/anyprint.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import functools
 import types
 


### PR DESCRIPTION
Without that future import `print` is a statment in python 2
That means:
- it doesn't allow keyword arguments like `end`
- you can't use it like a normal variable (e.g. in dict literals or as argument)

(note: I didn't test it, but without it will definitely not work on python 2)
(why do you do that crazy thing? it's nearly as bad as the `goto` statment for python)