### PR TITLE
More ruby-like puts and p

### DIFF
--- a/anyprint.py
+++ b/anyprint.py
@@ -46,8 +46,8 @@ prints = {
     'println': print,
 
     # C like
-    'puts': print,
     'printf': printf,
+    'puts': lambda *args: print(*args, sep='\n'),     # shared with Ruby
 
     # actionscript
     'trace': print,
@@ -139,7 +139,7 @@ prints = {
     'NSLog': lambda *args: print(args[0].replace('%@', '%s') % args[1:]),
 
     # Ruby
-    'p': lambda *args: print(*(repr(a) for a in args), sep='\n'),
+    'p': lambda *args: (print(*(repr(a) for a in args), sep='\n') and False) or list(args),
 }
 
 


### PR DESCRIPTION
* puts in C accepts just one string parameter, ruby's puts accepts more parameters and prints them (~str) on each line separately
* p in ruby prints the arguments as repr and returns them in an array

Tried to accommodate these subtle differences.